### PR TITLE
Fix access_token flow not returning the user info

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -172,7 +172,7 @@ export class GoogleTokenStrategy extends Strategy {
       }
 
       // Now we have to get the userinfo from the token
-      got.get(`https://www.googleapis.com/oauth2/v3/userinfo?access_token=${accessToken}`).then(userinfo => {
+      got.get(`https://www.googleapis.com/oauth2/v3/userinfo?access_token=${accessToken}`).json().then(userinfo => {
         this.done(null, userinfo)
       }).catch(e => {
         this.done(null, false, {


### PR DESCRIPTION
The access_token flow was failing to parse the response from https://www.googleapis.com/oauth2/v3/userinfo. Since the response's body comes back as a JSON object, we need to tell `got` to retrieve it directly.